### PR TITLE
Add missing app teardown in e2e test

### DIFF
--- a/packages/backend/test/app.e2e-spec.ts
+++ b/packages/backend/test/app.e2e-spec.ts
@@ -15,6 +15,8 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
+  afterAll(async () => await app.close());
+
   it('/ (GET)', () => {
     return request(app.getHttpServer())
       .get('/')


### PR DESCRIPTION
## Summary
- ensure NestJS application is closed in e2e test

## Testing
- `yarn --cwd packages/backend test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_684bcc1665f8833294817fecc3c0bd01